### PR TITLE
Uses UDM ROCK instead of upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ juju integrate sdcore-udm:fiveg_nrf sdcore-nrf
 
 ## Image
 
-**udm**: `omecproject/5gc-udm:master-6956659`
+**udm**: `ghcr.io/canonical/sdcore-udm:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   udm-image:
     type: oci-image
     description: OCI image for SD-Core's UDM
-    upstream-source: omecproject/5gc-udm:master-6956659
+    upstream-source: ghcr.io/canonical/sdcore-udm:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,8 +202,7 @@ class UDMOperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": "/bin/udm "
-                        f"--udmcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
+                        "command": "/bin/udm " f"--udmcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
                         "environment": self._environment_variables,
                     },
                 },

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,7 +202,7 @@ class UDMOperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": "/free5gc/udm/udm "
+                        "command": "/bin/udm "
                         f"--udmcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
                         "environment": self._environment_variables,
                     },


### PR DESCRIPTION
# Description

Uses UDM ROCK instead of upstream image.
Don't merge before the UDM [ROCK](https://github.com/canonical/sdcore-udm-rock/pull/1) is merged.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library