### PR TITLE
(TELCO-574) Block charm when NRF goes down

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==2.4.1
 jinja2
 lightkube
 lightkube-models

--- a/src/charm.py
+++ b/src/charm.py
@@ -66,6 +66,7 @@ class UDMOperatorCharm(CharmBase):
         self.framework.observe(self.on.udm_pebble_ready, self._configure_sdcore_udm)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_sdcore_udm)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_sdcore_udm)
+        self.framework.observe(self._nrf_requires.on.nrf_broken, self._on_nrf_broken)
         self.framework.observe(
             self.on.certificates_relation_created, self._on_certificates_relation_created
         )
@@ -130,6 +131,14 @@ class UDMOperatorCharm(CharmBase):
         restart = self._update_config_file()
         self._configure_pebble(restart=restart)
         self.unit.status = ActiveStatus()
+
+    def _on_nrf_broken(self, event: EventBase) -> None:
+        """Event handler for NRF relation broken.
+
+        Args:
+            event (NRFBrokenEvent): Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
 
     def _on_certificates_relation_created(self, event: EventBase) -> None:
         """Generates Private key."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,11 +3,13 @@
 # See LICENSE file for licensing details.
 
 
+import asyncio
 import logging
 from pathlib import Path
 
 import pytest
 import yaml
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +19,9 @@ NRF_APP_NAME = "sdcore-nrf"
 DATABASE_APP_NAME = "mongodb-k8s"
 
 
-async def _deploy_database(ops_test):
+async def _deploy_database(ops_test: OpsTest):
     """Deploy a MongoDB."""
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         DATABASE_APP_NAME,
         application_name=DATABASE_APP_NAME,
         channel="5/edge",
@@ -27,40 +29,42 @@ async def _deploy_database(ops_test):
     )
 
 
-async def _deploy_nrf(ops_test):
-    """Deploy a NRF."""
-    await ops_test.model.deploy(
+async def _deploy_nrf(ops_test: OpsTest):
+    await _deploy_database(ops_test)
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         NRF_APP_NAME,
         application_name=NRF_APP_NAME,
         channel="edge",
         trust=True,
     )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=DATABASE_APP_NAME, relation2=NRF_APP_NAME
+    )
 
 
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
-async def build_and_deploy(ops_test):
+async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
+    deploy_nrf = asyncio.create_task(_deploy_nrf(ops_test))
     charm = await ops_test.build_charm(".")
+    await deploy_nrf
     resources = {
         "udm-image": METADATA["resources"]["udm-image"]["upstream-source"],
     }
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         charm,
         resources=resources,
         application_name=APPLICATION_NAME,
         trust=True,
     )
-    await _deploy_database(ops_test)
-    await _deploy_nrf(ops_test)
 
 
 @pytest.mark.abort_on_fail
 async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
-    ops_test,
-    build_and_deploy,
+    ops_test: OpsTest, build_and_deploy
 ):
-    await ops_test.model.wait_for_idle(
+    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APPLICATION_NAME],
         status="blocked",
         timeout=1000,
@@ -68,18 +72,33 @@ async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
 
 
 @pytest.mark.abort_on_fail
-async def test_relate_and_wait_for_active_status(
-    ops_test,
-    build_and_deploy,
-):
-    await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=DATABASE_APP_NAME)
-
-    await ops_test.model.add_relation(
+async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{APPLICATION_NAME}:fiveg_nrf", relation2=NRF_APP_NAME
     )
-
-    await ops_test.model.wait_for_idle(
+    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APPLICATION_NAME],
         status="active",
         timeout=1000,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.remove_application(NRF_APP_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        NRF_APP_NAME,
+        application_name=NRF_APP_NAME,
+        channel="edge",
+        trust=True,
+    )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=f"{NRF_APP_NAME}:database", relation2=DATABASE_APP_NAME
+    )
+    await ops_test.model.add_relation(relation1=APPLICATION_NAME, relation2=NRF_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=300)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -101,4 +101,4 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
         relation1=f"{NRF_APP_NAME}:database", relation2=DATABASE_APP_NAME
     )
     await ops_test.model.add_relation(relation1=APPLICATION_NAME, relation2=NRF_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=300)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501


### PR DESCRIPTION
# Description

This PR adds handling of the NRF relation broken event.
If NRF will ever go down, the UDM charm will reflect that fact by going into `Blocked` state.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library