### PR TITLE
Enable auto-merging Renovate PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
 *       @canonical/telco
-*       app/renovate-approve

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @canonical/telco
+*       app/renovate-approve

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,12 @@
     "fileMatch": [
       "^tox.ini$"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ],
+  "platformAutomerge": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops==2.4.1
+ops
 jinja2
 lightkube
 lightkube-models


### PR DESCRIPTION
# Description

Enables auto-merging of Renovate PRs if minor version of patch was changed.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library