### PR TITLE
Enforce TLS Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,11 @@ A Charmed Operator for SD-Core's Unified Data Manager (UDM) component.
 juju deploy mongodb-k8s --channel 5/edge --trust
 juju deploy sdcore-nrf --channel edge --trust
 juju deploy sdcore-udm --channel edge --trust
+juju deploy self-signed-certificates --channel=beta
 
 juju integrate sdcore-nrf mongodb-k8s
+juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
 juju integrate sdcore-udm:fiveg_nrf sdcore-nrf
-```
-
-### Optional
-
-```bash
-juju deploy self-signed-certificates --channel=edge
 juju integrate sdcore-udm:certificates self-signed-certificates:certificates
 ```
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,6 +17,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APPLICATION_NAME = METADATA["name"]
 NRF_APP_NAME = "sdcore-nrf"
 DATABASE_APP_NAME = "mongodb-k8s"
+TLS_PROVIDER_APP_NAME = "self-signed-certificates"
 
 
 async def _deploy_database(ops_test: OpsTest):
@@ -42,13 +43,27 @@ async def _deploy_nrf(ops_test: OpsTest):
     )
 
 
+async def _deploy_tls_provider(ops_test: OpsTest):
+    """Deploy a TLS provider."""
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        TLS_PROVIDER_APP_NAME,
+        application_name=TLS_PROVIDER_APP_NAME,
+        channel="beta",
+    )
+
+
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
 async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
     deploy_nrf = asyncio.create_task(_deploy_nrf(ops_test))
+    deploy_tls = asyncio.create_task(_deploy_tls_provider(ops_test))
     charm = await ops_test.build_charm(".")
     await deploy_nrf
+    await deploy_tls
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME
+    )
     resources = {
         "udm-image": METADATA["resources"]["udm-image"]["upstream-source"],
     }
@@ -76,6 +91,9 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_de
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{APPLICATION_NAME}:fiveg_nrf", relation2=NRF_APP_NAME
     )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_APP_NAME
+    )
     await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APPLICATION_NAME],
         status="active",
@@ -100,5 +118,26 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{NRF_APP_NAME}:database", relation2=DATABASE_APP_NAME
     )
+    await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(relation1=APPLICATION_NAME, relation2=NRF_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_tls_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.remove_application(TLS_PROVIDER_APP_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        TLS_PROVIDER_APP_NAME,
+        application_name=TLS_PROVIDER_APP_NAME,
+        channel="beta",
+        trust=True,
+    )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_APP_NAME
+    )
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/unit/expected_udmcfg.yaml
+++ b/tests/unit/expected_udmcfg.yaml
@@ -6,7 +6,7 @@ configuration:
     bindingIPv4: 0.0.0.0
     port: 29503
     registerIPv4: 1.1.1.1
-    scheme: http
+    scheme: https
     tls:
       key: free5gc/support/TLS/udm.key
       log: free5gc/udmsslkey.log


### PR DESCRIPTION
# Description

Enforces TLS integration in the charm. Charm remains in blocked state until the certificates relation is created, and in waiting status until a certificate is stored.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library