### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-udm_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-udm-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,5 +39,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-udm_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-udm-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# SD-Core UDM Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-udm/badge.svg)](https://charmhub.io/sdcore-udm)
+# SD-Core UDM K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-udm-k8s/badge.svg)](https://charmhub.io/sdcore-udm-k8s)
 
-A Charmed Operator for SD-Core's Unified Data Manager (UDM) component.
+A Charmed K8s Operator for SD-Core's Unified Data Manager (UDM) component.
 
 ## Usage
 
 ```bash
 juju deploy mongodb-k8s --channel 5/edge --trust
-juju deploy sdcore-nrf --channel edge
-juju deploy sdcore-udm --channel edge
+juju deploy sdcore-nrf-k8s --channel edge
+juju deploy sdcore-udm-k8s --channel edge
 juju deploy self-signed-certificates --channel=beta
 
-juju integrate sdcore-nrf mongodb-k8s
-juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
-juju integrate sdcore-udm:fiveg_nrf sdcore-nrf
-juju integrate sdcore-udm:certificates self-signed-certificates:certificates
+juju integrate sdcore-nrf-k8s mongodb-k8s
+juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-udm-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
+juju integrate sdcore-udm-k8s:certificates self-signed-certificates:certificates
 ```
 
 ## Get the Home Network Public Key
 ```bash
-juju run sdcore-udm/leader get-home-network-public-key
+juju run sdcore-udm-k8s/leader get-home-network-public-key
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core UDM Operator for K8s
+# SD-Core UDM Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-udm-k8s/badge.svg)](https://charmhub.io/sdcore-udm-k8s)
 
 A Charmed Operator for SD-Core's Unified Data Manager (UDM) component for K8s.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core UDM K8s Operator
+# SD-Core UDM Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-udm-k8s/badge.svg)](https://charmhub.io/sdcore-udm-k8s)
 
-A Charmed K8s Operator for SD-Core's Unified Data Manager (UDM) component.
+A Charmed Operator for SD-Core's Unified Data Manager (UDM) component for K8s.
 
 ## Usage
 

--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -13,7 +13,7 @@ NRF information and another charm requiring this information.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_nrf.v0.fiveg_nrf
+charmcraft fetch-lib charms.sdcore_nrf_k8s.v0.fiveg_nrf
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -28,7 +28,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
 
 
 class DummyFiveGNRFProviderCharm(CharmBase):
@@ -103,14 +103,14 @@ from ops.model import Relation
 from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "cd132a12c2b34243bfd2bae8d08c32d6"
+LIBID = "14746bb6f8d34accbeac27ea50ff4715"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,12 +1,12 @@
-name: sdcore-udm
+name: sdcore-udm-k8s
 
-display-name: SD-Core 5G UDM
+display-name: SD-Core 5G UDM K8s
 summary: A Charmed Operator for SD-Core's UDM component.
 description: |
   A Charmed Operator for SD-Core's Unified Data Manager (UDM) component.
-website: https://charmhub.io/sdcore-udm
-source: https://github.com/canonical/sdcore-udm-operator
-issues: https://github.com/canonical/sdcore-udm-operator/issues
+website: https://charmhub.io/sdcore-udm-k8s
+source: https://github.com/canonical/sdcore-udm-k8s-operator
+issues: https://github.com/canonical/sdcore-udm-k8s-operator/issues
 
 containers:
   udm:

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,7 @@ from ipaddress import IPv4Address
 from subprocess import check_output
 from typing import Optional
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateAvailableEvent,
     CertificateExpiringEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the 5G UDM service."""
+"""Charmed K8s operator for the 5G UDM service."""
 
 import logging
 from ipaddress import IPv4Address
@@ -44,7 +44,7 @@ CERTIFICATE_NAME = "udm.pem"
 CERTIFICATE_COMMON_NAME = "udm.sdcore"
 
 
-class UDMOperatorCharm(CharmBase):
+class UDMK8sOperatorCharm(CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -507,4 +507,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":
-    main(UDMOperatorCharm)
+    main(UDMK8sOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed K8s operator for the 5G UDM service."""
+"""Charmed operator for the 5G UDM service for K8s."""
 
 import logging
 from ipaddress import IPv4Address
@@ -44,7 +44,7 @@ CERTIFICATE_NAME = "udm.pem"
 CERTIFICATE_COMMON_NAME = "udm.sdcore"
 
 
-class UDMK8sOperatorCharm(CharmBase):
+class UDMOperatorCharm(CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -507,4 +507,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":
-    main(UDMK8sOperatorCharm)
+    main(UDMOperatorCharm)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APPLICATION_NAME = METADATA["name"]
-NRF_APP_NAME = "sdcore-nrf"
+NRF_APP_NAME = "sdcore-nrf-k8s"
 DATABASE_APP_NAME = "mongodb-k8s"
 TLS_PROVIDER_APP_NAME = "self-signed-certificates"
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -156,7 +156,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("ops.model.Container.restart")
     def test_given_udm_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
         self, _, patched_nrf_url, patch_check_output
@@ -199,7 +199,7 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for NRF endpoint to be available"),
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_container_storage_is_not_attached_when_configure_sdcore_udm_then_status_is_waiting(  # noqa: E501
         self,
         patched_nrf_url,
@@ -217,7 +217,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_home_network_private_key_not_stored_when_configure_sdcore_udm_then_status_is_waiting(  # noqa: E501
         self,
         patched_nrf_url,
@@ -240,7 +240,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_config_file_is_not_written_when_configure_sdcore_udm_is_called_then_config_file_is_written_with_expected_content(  # noqa: E501
         self,
         patched_nrf_url,
@@ -269,7 +269,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_config_file_is_written_and_is_not_changed_when_configure_sdcore_udm_is_called_then_config_file_is_not_written(  # noqa: E501
         self, patched_nrf_url, patch_check_output
     ):
@@ -298,7 +298,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_config_file_is_written_and_is_not_changed_when_configure_sdcore_udm_is_called_then_after_writting_config_file_service_is_not_restarted(  # noqa: E501
         self, patched_nrf_url, patch_check_output, patch_restart
     ):
@@ -324,7 +324,7 @@ class TestCharm(unittest.TestCase):
         patch_restart.assert_not_called()
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_config_file_is_written_and_is_changed_when_configure_sdcore_udm_is_called_then_config_file_is_written(  # noqa: E501
         self,
         patched_nrf_url,
@@ -355,7 +355,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_config_file_is_written_and_is_changed_when_configure_sdcore_udm_is_called_then_after_writting_config_file_service_is_restarted(  # noqa: E501
         self,
         patched_nrf_url,
@@ -382,7 +382,7 @@ class TestCharm(unittest.TestCase):
         patch_container_restart.assert_called_with(self.container_name)
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("ops.model.Container.restart")
     def test_given_config_file_is_written_when_configure_sdcore_udm_is_called_then_pebble_plan_is_applied(  # noqa: E501
         self, _, patched_nrf_url, patch_check_output
@@ -426,7 +426,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(expected_plan, updated_plan)
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("ops.Container.push")
     @patch("ops.model.Container.restart")
     def test_given_config_file_is_written_when_configure_sdcore_udm_is_called_then_status_is_active(  # noqa: E501
@@ -452,7 +452,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_ip_not_available_when_configure_then_status_is_waiting(
         self, _, patch_check_output
     ):
@@ -469,7 +469,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_certificate_is_not_stored_when_configure_sdcore_udm_then_status_is_waiting(  # noqa: E501
         self,
         patch_nrf_url,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import CONFIG_FILE_NAME, NRF_RELATION_NAME, TLS_RELATION_NAME, UDMOperatorCharm
+from charm import CONFIG_FILE_NAME, NRF_RELATION_NAME, TLS_RELATION_NAME, UDMK8sOperatorCharm
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class TestCharm(unittest.TestCase):
         self.namespace = "whatever"
         self.metadata = self._get_metadata()
         self.container_name = list(self.metadata["containers"].keys())[0]
-        self.harness = testing.Harness(UDMOperatorCharm)
+        self.harness = testing.Harness(UDMK8sOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import CONFIG_FILE_NAME, NRF_RELATION_NAME, TLS_RELATION_NAME, UDMK8sOperatorCharm
+from charm import CONFIG_FILE_NAME, NRF_RELATION_NAME, TLS_RELATION_NAME, UDMOperatorCharm
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class TestCharm(unittest.TestCase):
         self.namespace = "whatever"
         self.metadata = self._get_metadata()
         self.container_name = list(self.metadata["containers"].keys())[0]
-        self.harness = testing.Harness(UDMK8sOperatorCharm)
+        self.harness = testing.Harness(UDMOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . 

- Fetch new fiveg_nrf library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library